### PR TITLE
Allow Dreamers, Skills, and Keys to be false for Item Rando.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,123 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+############################### 
+# Core EditorConfig Options   # 
+############################### 
+# All files 
+[*] 
+indent_style = space 
+# Code files 
+[*.{cs,csx,vb,vbx}] 
+indent_size = 4 
+insert_final_newline = true 
+charset = utf-8-bom 
+############################### 
+# .NET Coding Conventions     # 
+############################### 
+[*.{cs,vb}] 
+# Organize usings 
+dotnet_sort_system_directives_first = true 
+# this. preferences 
+dotnet_style_qualification_for_field = false:silent 
+dotnet_style_qualification_for_property = false:silent 
+dotnet_style_qualification_for_method = false:silent 
+dotnet_style_qualification_for_event = false:silent 
+# Language keywords vs BCL types preferences 
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent 
+dotnet_style_predefined_type_for_member_access = true:silent 
+# Parentheses preferences 
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent 
+# Modifier preferences 
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent 
+dotnet_style_readonly_field = true:suggestion 
+# Expression-level preferences 
+dotnet_style_object_initializer = true:suggestion 
+dotnet_style_collection_initializer = true:suggestion 
+dotnet_style_explicit_tuple_names = true:suggestion 
+dotnet_style_null_propagation = true:suggestion 
+dotnet_style_coalesce_expression = true:suggestion 
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent 
+dotnet_prefer_inferred_tuple_names = true:suggestion 
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion 
+dotnet_style_prefer_auto_properties = true:silent 
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent 
+dotnet_style_prefer_conditional_expression_over_return = true:silent 
+############################### 
+# Naming Conventions          # 
+############################### 
+# Style Definitions 
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case 
+# Use PascalCase for constant fields   
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style 
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field 
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = * 
+dotnet_naming_symbols.constant_fields.required_modifiers          = const 
+############################### 
+# C# Coding Conventions       # 
+############################### 
+[*.cs] 
+# var preferences 
+csharp_style_var_for_built_in_types = false:silent 
+csharp_style_var_when_type_is_apparent = false:silent 
+csharp_style_var_elsewhere = false:silent 
+# Expression-bodied members 
+csharp_style_expression_bodied_methods = false:silent 
+csharp_style_expression_bodied_constructors = false:silent 
+csharp_style_expression_bodied_operators = false:silent 
+csharp_style_expression_bodied_properties = true:silent 
+csharp_style_expression_bodied_indexers = true:silent 
+csharp_style_expression_bodied_accessors = true:silent 
+# Pattern matching preferences 
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion 
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion 
+# Null-checking preferences 
+csharp_style_throw_expression = true:suggestion 
+csharp_style_conditional_delegate_call = true:suggestion 
+# Modifier preferences 
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion 
+# Expression-level preferences 
+csharp_prefer_braces = true:silent 
+csharp_style_deconstructed_variable_declaration = true:suggestion 
+csharp_prefer_simple_default_expression = true:suggestion 
+csharp_style_pattern_local_over_anonymous_function = true:suggestion 
+csharp_style_inlined_variable_declaration = true:suggestion 
+############################### 
+# C# Formatting Rules         # 
+############################### 
+# New line preferences 
+csharp_new_line_before_open_brace = all 
+csharp_new_line_before_else = true 
+csharp_new_line_before_catch = true 
+csharp_new_line_before_finally = true 
+csharp_new_line_before_members_in_object_initializers = true 
+csharp_new_line_before_members_in_anonymous_types = true 
+csharp_new_line_between_query_expression_clauses = true 
+# Indentation preferences 
+csharp_indent_case_contents = true 
+csharp_indent_switch_labels = true 
+csharp_indent_labels = flush_left 
+# Space preferences 
+csharp_space_after_cast = false 
+csharp_space_after_keywords_in_control_flow_statements = true 
+csharp_space_between_method_call_parameter_list_parentheses = false 
+csharp_space_between_method_declaration_parameter_list_parentheses = false 
+csharp_space_between_parentheses = false 
+csharp_space_before_colon_in_inheritance_clause = true 
+csharp_space_after_colon_in_inheritance_clause = true 
+csharp_space_around_binary_operators = before_and_after 
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false 
+csharp_space_between_method_call_name_and_opening_parenthesis = false 
+csharp_space_between_method_call_empty_parameter_list_parentheses = false 
+# Wrapping preferences 
+csharp_preserve_single_line_statements = true 
+csharp_preserve_single_line_blocks = true 
+############################### 
+# VB Coding Conventions       # 
+############################### 
+[*.vb] 
+# Modifier preferences 
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion 

--- a/RandomizerMod3.0.sln
+++ b/RandomizerMod3.0.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 16.0.28803.202
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RandomizerMod3.0", "RandomizerMod3.0\RandomizerMod3.0.csproj", "{2A00B777-CBA2-409B-BB29-3339C92CCACC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{88DDED69-61C0-4F5F-9E11-48CAE9425812}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/RandomizerMod3.0/LanguageStringManager.cs
+++ b/RandomizerMod3.0/LanguageStringManager.cs
@@ -84,7 +84,7 @@ namespace RandomizerMod
             if (sheetTitle == "Quirrel" && RandomizerMod.Instance.Settings.Quirrel && RandomizerMod.Instance.Settings.QuirrerHintCounter < 3 &&
                 new List<string> { "QUIRREL_MEET_TEMPLE_C", "QUIRREL_GREENPATH_1", "QUIRREL_QUEENSTATION_01", "QUIRREL_MANTIS_01", "QUIRREL_RUINS_1", "QUIRREL_SPA", "QUIRREL_MINES_2", "QUIRREL_FOGCANYON_A", "QUIRREL_EPILOGUE_A" }.Contains(key))
             {
-                return GetQuirrelHint(key);
+                return GetQuirrelHint(key, sheetTitle);
             }
             if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(sheetTitle))
             {
@@ -185,7 +185,7 @@ namespace RandomizerMod
             return firstMessage + secondMessage;
         }
 
-        public static string GetQuirrelHint(string key)
+        public static string GetQuirrelHint(string key, string sheetTitle)
         {
             RandomizerMod.Instance.Settings.QuirrerHintCounter++;
             string hint = string.Empty;
@@ -370,6 +370,9 @@ namespace RandomizerMod
                     LogWarn("Unknown key passed to GetQuirrelHint");
                     break;
             }
+            if (hint == string.Empty)
+                return Language.Language.GetInternal(key, sheetTitle);
+
             RandoLogger.LogHintToTracker(hint, jiji: false, quirrel: true);
             return hint;
         }

--- a/RandomizerMod3.0/MenuChanger.cs
+++ b/RandomizerMod3.0/MenuChanger.cs
@@ -7,6 +7,7 @@ using UnityEngine.UI;
 using static RandomizerMod.LogHelper;
 using Object = UnityEngine.Object;
 using Random = System.Random;
+using RandomizerMod.Randomization;
 
 namespace RandomizerMod
 {
@@ -57,6 +58,8 @@ namespace RandomizerMod
             RandoMenuItem<bool> RandoDreamersBtn = new RandoMenuItem<bool>(back, new Vector2(900, 960), "Dreamers", true, false);
             RandoMenuItem<bool> RandoSkillsBtn = new RandoMenuItem<bool>(back, new Vector2(900, 880), "Skills", true, false);
             RandoMenuItem<bool> RandoCharmsBtn = new RandoMenuItem<bool>(back, new Vector2(900, 800), "Charms", true, false);
+            RandoCharmsBtn.SetSelection(true);
+            RandoCharmsBtn.Lock();
             RandoMenuItem<bool> RandoKeysBtn = new RandoMenuItem<bool>(back, new Vector2(900, 720), "Keys", true, false);
             RandoMenuItem<bool> RandoGeoChestsBtn = new RandoMenuItem<bool>(back, new Vector2(900, 640), "Geo Chests", false, true);
             RandoMenuItem<bool> RandoMaskBtn = new RandoMenuItem<bool>(back, new Vector2(900, 560), "Mask Shards", false, true);
@@ -185,7 +188,7 @@ namespace RandomizerMod
                 {
                     RandoDreamersBtn.Unlock();
                     RandoSkillsBtn.Unlock();
-                    RandoCharmsBtn.Unlock();
+                    //RandoCharmsBtn.Unlock();
                     RandoKeysBtn.Unlock();
                 }
                 else

--- a/RandomizerMod3.0/MenuChanger.cs
+++ b/RandomizerMod3.0/MenuChanger.cs
@@ -24,9 +24,9 @@ namespace RandomizerMod
 
             Object.Destroy(playScreen.topFleur.gameObject);
 
-            MenuButton classic = (MenuButton) playScreen.defaultHighlight;
-            MenuButton steel = (MenuButton) classic.FindSelectableOnDown();
-            MenuButton back = (MenuButton) steel.FindSelectableOnDown();
+            MenuButton classic = (MenuButton)playScreen.defaultHighlight;
+            MenuButton steel = (MenuButton)classic.FindSelectableOnDown();
+            MenuButton back = (MenuButton)steel.FindSelectableOnDown();
 
             GameObject parent = steel.transform.parent.gameObject;
 
@@ -46,7 +46,7 @@ namespace RandomizerMod
             startNormalBtn.transform.localScale = 
                 startSteelNormalBtn.transform.localScale =
                     startSteelRandoBtn.transform.localScale = */
-                    startRandoBtn.transform.localScale = new Vector2(0.75f, 0.75f);
+            startRandoBtn.transform.localScale = new Vector2(0.75f, 0.75f);
 
             MenuButton backBtn = back.Clone("Back", MenuButton.MenuButtonType.Proceed, new Vector2(0, -100), "Back");
 
@@ -54,10 +54,10 @@ namespace RandomizerMod
             //RandoMenuItem<string> gameTypeBtn = new RandoMenuItem<string>(back, new Vector2(0, 600), "Game Type", "Normal", "Steel Soul");
 
             RandoMenuItem<string> presetPoolsBtn = new RandoMenuItem<string>(back, new Vector2(900, 1040), "Preset", "Progressive", "Completionist", "Junk Pit", "Custom");
-            RandoMenuItem<bool> RandoDreamersBtn = new RandoMenuItem<bool>(back, new Vector2(900, 960), "Dreamers", true);
-            RandoMenuItem<bool> RandoSkillsBtn = new RandoMenuItem<bool>(back, new Vector2(900, 880), "Skills", true);
-            RandoMenuItem<bool> RandoCharmsBtn = new RandoMenuItem<bool>(back, new Vector2(900, 800), "Charms", true);
-            RandoMenuItem<bool> RandoKeysBtn = new RandoMenuItem<bool>(back, new Vector2(900, 720), "Keys", true);
+            RandoMenuItem<bool> RandoDreamersBtn = new RandoMenuItem<bool>(back, new Vector2(900, 960), "Dreamers", true, false);
+            RandoMenuItem<bool> RandoSkillsBtn = new RandoMenuItem<bool>(back, new Vector2(900, 880), "Skills", true, false);
+            RandoMenuItem<bool> RandoCharmsBtn = new RandoMenuItem<bool>(back, new Vector2(900, 800), "Charms", true, false);
+            RandoMenuItem<bool> RandoKeysBtn = new RandoMenuItem<bool>(back, new Vector2(900, 720), "Keys", true, false);
             RandoMenuItem<bool> RandoGeoChestsBtn = new RandoMenuItem<bool>(back, new Vector2(900, 640), "Geo Chests", false, true);
             RandoMenuItem<bool> RandoMaskBtn = new RandoMenuItem<bool>(back, new Vector2(900, 560), "Mask Shards", false, true);
             RandoMenuItem<bool> RandoVesselBtn = new RandoMenuItem<bool>(back, new Vector2(900, 480), "Vessel Fragments", false, true);
@@ -81,7 +81,7 @@ namespace RandomizerMod
             RandoMenuItem<bool> EarlyGeoBtn = new RandoMenuItem<bool>(back, new Vector2(-900, 120), "Early Geo", true, false);
             RandoMenuItem<bool> jijiBtn = new RandoMenuItem<bool>(back, new Vector2(-900, 40), "Jiji Hints", true, false);
             RandoMenuItem<bool> quirrelBtn = new RandoMenuItem<bool>(back, new Vector2(-900, -40), "Quirrel Hints", true, false);
-            
+
 
             RandoMenuItem<string> modeBtn = new RandoMenuItem<string>(back, new Vector2(0, 1040), "Mode", "Item Randomizer", "Area Randomizer", "Connected-Area Room Randomizer", "Room Randomizer");
             RandoMenuItem<string> cursedBtn = new RandoMenuItem<string>(back, new Vector2(0, 960), "Cursed", "no", "noo", "noooo", "noooooooo", "noooooooooooooooo", "Oh yeah");
@@ -161,7 +161,7 @@ namespace RandomizerMod
             EarlyGeoBtn.Button.SetNavigation(lemmBtn.Button, startRandoBtn, jijiBtn.Button, EarlyGeoBtn.Button);
             jijiBtn.Button.SetNavigation(EarlyGeoBtn.Button, startRandoBtn, quirrelBtn.Button, jijiBtn.Button);
             quirrelBtn.Button.SetNavigation(jijiBtn.Button, startRandoBtn, presetSkipsBtn.Button, quirrelBtn.Button);
-            
+
 
             presetPoolsBtn.Button.SetNavigation(RandoSpoilerBtn.Button, presetPoolsBtn.Button, RandoDreamersBtn.Button, startRandoBtn);
             RandoDreamersBtn.Button.SetNavigation(presetPoolsBtn.Button, RandoDreamersBtn.Button, RandoSkillsBtn.Button, startRandoBtn);
@@ -178,6 +178,29 @@ namespace RandomizerMod
             RandoSpoilerBtn.Button.SetNavigation(RandoRelicsBtn.Button, RandoSpoilerBtn.Button, presetPoolsBtn.Button, startRandoBtn);
 
             // Setup event for changing difficulty settings buttons
+            void ModeSettingChanged(RandoMenuItem<string> item)
+            {
+                //"Item Randomizer", "Area Randomizer", "Connected-Area Room Randomizer", "Room Randomizer"
+                if (item.CurrentSelection == "Item Randomizer")
+                {
+                    RandoDreamersBtn.Unlock();
+                    RandoSkillsBtn.Unlock();
+                    RandoCharmsBtn.Unlock();
+                    RandoKeysBtn.Unlock();
+                }
+                else
+                {
+                    RandoDreamersBtn.SetSelection(true);
+                    RandoSkillsBtn.SetSelection(true);
+                    RandoCharmsBtn.SetSelection(true);
+                    RandoKeysBtn.SetSelection(true);
+                    RandoDreamersBtn.Lock();
+                    RandoSkillsBtn.Lock();
+                    RandoCharmsBtn.Lock();
+                    RandoKeysBtn.Lock();
+                }
+            }
+
             void UpdateSkipsButtons(RandoMenuItem<string> item)
             {
                 switch (item.CurrentSelection)
@@ -280,6 +303,8 @@ namespace RandomizerMod
                 presetPoolsBtn.SetSelection("Custom");
             }
 
+            modeBtn.Changed += ModeSettingChanged;
+
             presetSkipsBtn.Changed += UpdateSkipsButtons;
             presetPoolsBtn.Changed += UpdatePoolPreset;
 
@@ -356,12 +381,12 @@ namespace RandomizerMod
                 {
                     RandomizerMod.Instance.Settings.Jiji = jijiBtn.CurrentSelection;
                     RandomizerMod.Instance.Settings.Quirrel = quirrelBtn.CurrentSelection;
-                    
 
-                    RandomizerMod.Instance.Settings.RandomizeDreamers = true;
-                    RandomizerMod.Instance.Settings.RandomizeSkills = true;
-                    RandomizerMod.Instance.Settings.RandomizeCharms = true;
-                    RandomizerMod.Instance.Settings.RandomizeKeys = true;
+
+                    RandomizerMod.Instance.Settings.RandomizeDreamers = RandoDreamersBtn.CurrentSelection;
+                    RandomizerMod.Instance.Settings.RandomizeSkills = RandoSkillsBtn.CurrentSelection;
+                    RandomizerMod.Instance.Settings.RandomizeCharms = RandoCharmsBtn.CurrentSelection;
+                    RandomizerMod.Instance.Settings.RandomizeKeys = RandoKeysBtn.CurrentSelection;
                     RandomizerMod.Instance.Settings.RandomizeGeoChests = RandoGeoChestsBtn.CurrentSelection;
                     RandomizerMod.Instance.Settings.RandomizeMaskShards = RandoMaskBtn.CurrentSelection;
                     RandomizerMod.Instance.Settings.RandomizeVesselFragments = RandoVesselBtn.CurrentSelection;
@@ -424,6 +449,7 @@ namespace RandomizerMod
             private readonly T[] _selections;
             private readonly Text _text;
             private int _currentSelection;
+            private bool _locked = false;
 
             public RandoMenuItem(MenuButton baseObj, Vector2 position, string name, params T[] values)
             {
@@ -473,6 +499,8 @@ namespace RandomizerMod
 
             public void SetSelection(T obj)
             {
+                if (_locked) return;
+
                 for (int i = 0; i < _selections.Length; i++)
                 {
                     if (_selections[i].Equals(obj))
@@ -487,6 +515,8 @@ namespace RandomizerMod
 
             private void GotoNext(BaseEventData data = null)
             {
+                if (_locked) return;
+
                 _currentSelection++;
                 if (_currentSelection >= _selections.Length)
                 {
@@ -505,6 +535,18 @@ namespace RandomizerMod
                 {
                     ChangedInternal?.Invoke(this);
                 }
+            }
+
+            internal void Lock()
+            {
+                _text.color = Color.grey;
+                _locked = true;
+            }
+
+            internal void Unlock()
+            {
+                _text.color = Color.white;
+                _locked = false;
             }
         }
     }

--- a/RandomizerMod3.0/MiscSceneChanges.cs
+++ b/RandomizerMod3.0/MiscSceneChanges.cs
@@ -632,7 +632,7 @@ namespace RandomizerMod
                     }
                     break;
                 case SceneNames.Room_Mansion:
-                    LanguageStringManager.SetString("Prompts", "XUN_OFFER", "Accept the Gift, even knowing you'll only get a lousy " + RandomizerMod.Instance.Settings.ItemPlacements.FirstOrDefault(pair => pair.Item2 == "Mask_Shard-Grey_Mourner").Item1.Split('-').First().Replace('_', ' ') + "?");
+                    LanguageStringManager.SetString("Prompts", "XUN_OFFER", "Accept the Gift, even knowing you'll get a " + RandomizerMod.Instance.Settings.ItemPlacements.FirstOrDefault(pair => pair.Item2 == "Mask_Shard-Grey_Mourner").Item1.Split('-').First().Replace('_', ' ') + "?");
                     if (PlayerData.instance.xunFlowerGiven)
                     {
                         PlayerData.instance.xunRewardGiven = true;

--- a/RandomizerMod3.0/Randomization/ItemManager.cs
+++ b/RandomizerMod3.0/Randomization/ItemManager.cs
@@ -164,6 +164,14 @@ namespace RandomizerMod.Randomization
             return locations;
         }
 
+        public void QueueUpdate(string newThing, ProgressionManager _pm = null)
+        {
+            if (_pm != null) pm = _pm;
+
+            pm.Add(newThing);
+            updateQueue.Enqueue(newThing);
+        }
+
         public void ResetReachableLocations()
         {
             reachableLocations = new HashSet<string>();
@@ -322,7 +330,7 @@ namespace RandomizerMod.Randomization
                 return false;
             }
 
-            for (int i=0; i < unplacedProgression.Count; i++)
+            for (int i = 0; i < unplacedProgression.Count; i++)
             {
                 string item = unplacedProgression[i];
                 pm.Add(item);
@@ -340,7 +348,7 @@ namespace RandomizerMod.Randomization
                     if (found) return item;
                     foreach (string transition in tempProgression) pm.Remove(transition);
                 }
-                
+
                 pm.Remove(item);
             }
             return null;
@@ -371,9 +379,7 @@ namespace RandomizerMod.Randomization
             if (LogicManager.GetItemDef(item).progression)
             {
                 unplacedProgression.Remove(item);
-                pm.Add(item);
-                updateQueue.Enqueue(item);
-                UpdateReachableLocations();
+                UpdateReachableLocations(item);
             }
             else unplacedItems.Remove(item);
         }
@@ -390,9 +396,7 @@ namespace RandomizerMod.Randomization
         {
             unplacedProgression.Remove(item);
             standbyProgression.Add(item);
-            pm.Add(item);
-            updateQueue.Enqueue(item);
-            UpdateReachableLocations();
+            UpdateReachableLocations(item);
         }
 
         public void PlaceJunkItemToStandby(string item, string location)
@@ -406,7 +410,7 @@ namespace RandomizerMod.Randomization
         private void LogDataConflicts()
         {
             string stuff = pm.ListObtainedProgression();
-            foreach(string _item in stuff.Split(','))
+            foreach (string _item in stuff.Split(','))
             {
                 string item = _item.Trim();
                 if (string.IsNullOrEmpty(item)) continue;

--- a/RandomizerMod3.0/Randomization/LogicManager.cs
+++ b/RandomizerMod3.0/Randomization/LogicManager.cs
@@ -45,6 +45,7 @@ namespace RandomizerMod.Randomization
         public string boolName;
         public string sceneName;
         public string objectName;
+        public string shopName;
         public string altObjectName;
         public string fsmName;
         public bool replace;
@@ -75,8 +76,6 @@ namespace RandomizerMod.Randomization
         public string shopDescKey;
         public string shopSpriteKey;
         public string notchCost;
-
-        public string shopName;
 
         // Trinket variables
         public int trinketNum;
@@ -140,6 +139,7 @@ namespace RandomizerMod.Randomization
         public static int bitMaskMax;
         public static int essenceIndex;
         public static int grubIndex;
+        public static Dictionary<string, (int, int)> itemCountsByPool = null;
 
         public static string[] ItemNames => _items.Keys.ToArray();
 
@@ -297,6 +297,25 @@ namespace RandomizerMod.Randomization
             }
 
             return def;
+        }
+
+        public static (int, int) GetPoolCount(string poolName)
+        {
+            //Lazy init
+            if (itemCountsByPool == null)
+            {
+                itemCountsByPool = new Dictionary<string, (int, int)>();
+                foreach (string pool in _poolIndexedItems.Keys)
+                {
+                    int poolCount = _poolIndexedItems[pool].Count();
+                    int progCount = _poolIndexedItems[pool].Where(val => GetItemDef(val).progression).Count();
+                    itemCountsByPool.Add(pool, (progCount, poolCount));
+                    Log($"Pool '{pool}' has {progCount} progression out of {poolCount} total items.");
+                }
+            }
+
+            //Actual Function
+            return itemCountsByPool[poolName];
         }
 
         public static bool ParseProcessedLogic(string item, int[] obtained)

--- a/RandomizerMod3.0/Randomization/VanillaManager.cs
+++ b/RandomizerMod3.0/Randomization/VanillaManager.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RandomizerMod.Randomization
+{
+    class VanillaManager
+    {
+        private static VanillaManager inst = null;
+        public static VanillaManager Instance { get
+            {
+                if (inst == null)
+                {
+                    inst = new VanillaManager();
+                }
+
+                return inst;
+            }
+        }
+
+
+
+
+
+
+
+
+
+
+        private ItemManager im;
+        public List<string> locationsObtained;
+        public List<string> progressionLocations;
+        public Dictionary<string, List<string>> progressionShopItems;
+        public Dictionary<string, string> progressionNonShopItems;
+
+		public List<(string, string)> ItemPlacements { get; private set; }
+
+		public VanillaManager()
+        {
+            // Pass
+        }
+
+        internal void Setup(ItemManager im)
+        {
+            this.im = im;
+
+            ItemPlacements = new List<(string, string)>();
+
+            progressionLocations = new List<string>();
+            progressionShopItems = new Dictionary<string, List<string>>();
+            progressionNonShopItems = new Dictionary<string, string>();
+
+            //Set up vanillaLocations
+            //    Not as cool as all the hashset union stuff :(
+            foreach (string item in GetVanillaItems())
+            {
+                ReqDef itemDef = LogicManager.GetItemDef(item);
+                if (itemDef.type == ItemType.Shop && LogicManager.ShopNames.Contains(itemDef.shopName))
+                {
+                    ItemPlacements.Add((item, itemDef.shopName));
+
+                    //Add shop to locations
+                    if (itemDef.progression && !progressionLocations.Contains(itemDef.shopName))
+                        progressionLocations.Add(itemDef.shopName);
+
+                    //Add items to the shop items
+                    if (itemDef.progression)
+                    {
+                        if (progressionShopItems.ContainsKey(itemDef.shopName))
+                            //Shop's here, but item's not.
+                            progressionShopItems[itemDef.shopName].Add(item);
+                        else
+                            //Shop's not here, so add the shop and the item to it.
+                            progressionShopItems.Add(itemDef.shopName, new List<string>() { item });
+                    }
+
+                    continue;
+                } else
+                {
+                    ItemPlacements.Add((item, item));
+                    //Not a shop!
+                    if (itemDef.progression)
+                        progressionNonShopItems.Add(item, item);
+                }
+
+                if (itemDef.progression)
+                    progressionLocations.Add(item);
+            }
+        }
+
+        internal void ResetReachableLocations(bool doUpdateQueue = true, ProgressionManager _pm = null)
+        {
+            if (_pm == null) _pm = im.pm;
+            locationsObtained = new List<string>();
+            if (!doUpdateQueue) return;
+
+            foreach (string location in progressionLocations)
+            {
+                if (_pm.CanGet(location))
+                    UpdateVanillaLocations(location, doUpdateQueue);
+            }
+            if (doUpdateQueue) im.UpdateReachableLocations();
+        }
+
+        internal void UpdateVanillaLocations(string location, bool doUpdateQueue = true, ProgressionManager _pm = null)
+        {
+            if (_pm == null) _pm = im.pm;
+            if (locationsObtained.Contains(location))
+            {
+                return;
+            }
+
+            if (progressionShopItems.ContainsKey(location))
+            { // shop in vanilla
+                foreach (string shopItem in progressionShopItems[location])
+                {
+                    _pm.Add(shopItem);
+                    if (doUpdateQueue) im.updateQueue.Enqueue(shopItem);
+                }
+            }
+            else
+            { // item in vanilla
+                _pm.Add(location);
+                if (doUpdateQueue) im.updateQueue.Enqueue(location);
+            }
+
+            locationsObtained.Add(location);
+        }
+
+        private HashSet<string> GetVanillaItems()
+        {
+            HashSet<string> unrandoItems = new HashSet<string>();
+
+            if (!RandomizerMod.Instance.Settings.RandomizeDreamers) unrandoItems.UnionWith(LogicManager.GetItemsByPool("Dreamer"));
+            if (!RandomizerMod.Instance.Settings.RandomizeSkills) unrandoItems.UnionWith(LogicManager.GetItemsByPool("Skill"));
+            if (!RandomizerMod.Instance.Settings.RandomizeCharms) unrandoItems.UnionWith(LogicManager.GetItemsByPool("Charm"));
+            if (!RandomizerMod.Instance.Settings.RandomizeKeys) unrandoItems.UnionWith(LogicManager.GetItemsByPool("Key"));
+
+            return unrandoItems;
+        }
+    }
+}

--- a/RandomizerMod3.0/RandomizerMod.cs
+++ b/RandomizerMod3.0/RandomizerMod.cs
@@ -176,6 +176,8 @@ namespace RandomizerMod
             try
             {
                 Randomizer.Randomize();
+
+                RandoLogger.UpdateHelperLog();
             }
             catch (Exception e)
             {

--- a/RandomizerMod3.0/RandomizerMod3.0.csproj
+++ b/RandomizerMod3.0/RandomizerMod3.0.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Randomization\TransitionManager.cs" />
     <Compile Include="Randomization\ProgressionManager.cs" />
     <Compile Include="Randomization\LogicManager.cs" />
+    <Compile Include="Randomization\VanillaManager.cs" />
     <Compile Include="RandomizerMod.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Randomization\Randomizer.cs" />

--- a/RandomizerMod3.0/Resources/items.xml
+++ b/RandomizerMod3.0/Resources/items.xml
@@ -518,6 +518,7 @@
     <boolName>gotCharm_1</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -534,6 +535,7 @@
     <boolName>gotCharm_2</boolName>
     <sceneName>Room_mapper</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Iselda</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -569,6 +571,7 @@
     <boolName>gotCharm_4</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -622,6 +625,7 @@
     <boolName>gotCharm_7</boolName>
     <sceneName>Room_Charm_Shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Salubra</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -638,6 +642,7 @@
     <boolName>gotCharm_8</boolName>
     <sceneName>Room_Charm_Shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Salubra</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -744,6 +749,7 @@
     <boolName>gotCharm_14</boolName>
     <sceneName>Room_Charm_Shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Salubra</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -760,6 +766,7 @@
     <boolName>gotCharm_15</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly_(Key)</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -812,6 +819,7 @@
     <boolName>gotCharm_18</boolName>
     <sceneName>Room_Charm_Shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Salubra</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -828,6 +836,7 @@
     <boolName>gotCharm_19</boolName>
     <sceneName>Room_Charm_Shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Salubra</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -839,6 +848,7 @@
     <shopSpriteKey>Charms.19</shopSpriteKey>
     <areaName>Forgotten_Crossroads</areaName>
     <notchCost>charmCost_19</notchCost>
+    
   </item>
   <item name="Soul_Catcher">
     <boolName>gotCharm_20</boolName>
@@ -896,6 +906,7 @@
     <boolName>gotCharm_23</boolName>
     <sceneName>Fungus2_26</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Leg_Eater</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -912,6 +923,7 @@
     <boolName>gotCharm_24</boolName>
     <sceneName>Fungus2_26</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Leg_Eater</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -928,6 +940,7 @@
     <boolName>gotCharm_25</boolName>
     <sceneName>Fungus2_26</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Leg_Eater</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1193,6 +1206,7 @@
     <boolName>gotCharm_37</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly_(Key)</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1284,6 +1298,7 @@
     <boolName>hasLantern</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1324,6 +1339,7 @@
     <boolName>RandomizerMod.SlySimpleKey</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1420,6 +1436,7 @@
     <boolName>RandomizerMod.hasWhiteKey</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly_(Key)</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1525,6 +1542,7 @@
     <boolName>RandomizerMod.MaskShardSly1</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1542,6 +1560,7 @@
     <boolName>RandomizerMod.MaskShardSly2</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1559,6 +1578,7 @@
     <boolName>RandomizerMod.MaskShardSly3</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly_(Key)</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1576,6 +1596,7 @@
     <boolName>RandomizerMod.MaskShardSly4</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly_(Key)</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1792,6 +1813,7 @@
     <boolName>RandomizerMod.VesselFragmentSly1</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -1809,6 +1831,7 @@
     <boolName>RandomizerMod.VesselFragmentSly2</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly_(Key)</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>
@@ -2267,6 +2290,7 @@
     <boolName>RandomizerMod.RancidEggSly</boolName>
     <sceneName>Room_shop</sceneName>
     <objectName>Shop Menu</objectName>
+    <shopName>Sly</shopName>
     <replace>false</replace>
     <itemLogic></itemLogic>
     <areaLogic></areaLogic>


### PR DESCRIPTION
Force true for other modes. Made force have visual feedback.

Other minor changes include:
-Added .editorconfig file to help enforce whitespace/newline conventions
-Collapsed a few redundant method calls in ItemManager (UpdateReachable)
-Added a QueueUpdate to ItemManager; if we're calling lots of Updates at once we don't want to loop through all of that more than once