### PR TITLE
Fix Completion %

### DIFF
--- a/RandomizerMod3.0/RandomizerMod.cs
+++ b/RandomizerMod3.0/RandomizerMod.cs
@@ -205,7 +205,14 @@ namespace RandomizerMod
                 return;
             }
 
-            float rawPercent = ((float)RandomizerMod.Instance.Settings.GetItemsFound().Length / (float)RandomizerMod.Instance.Settings.GetPlacedItems().Count) * 100f;
+            float placedItems = (float)RandomizerMod.Instance.Settings.GetNumLocations();
+            if (placedItems == 0)
+            {
+                PlayerData.instance.completionPercentage = 0;
+                return;
+            }
+
+            float rawPercent = ((float)RandomizerMod.Instance.Settings.GetItemsFound().Length / placedItems) * 100f;
 
             PlayerData.instance.completionPercentage = (float)Math.Floor(rawPercent);
         }

--- a/RandomizerMod3.0/SaveSettings.cs
+++ b/RandomizerMod3.0/SaveSettings.cs
@@ -452,6 +452,11 @@ namespace RandomizerMod
             return _obtainedItems.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToArray();
         }
 
+        public int GetNumLocations()
+        {
+            return _orderedLocations.Count + _shopCosts.Count - 4;;
+        }
+
         public HashSet<string> GetPlacedItems()
         {
             return new HashSet<string>(ItemPlacements.Select(pair => pair.Item1));


### PR DESCRIPTION
Completion % should only count items randomized for the denominator, and not all SJP item locations.