### PR TITLE
Add costs to spoiler log

### DIFF
--- a/RandomizerMod3.0/Actions/ChangeShinyIntoBigItem.cs
+++ b/RandomizerMod3.0/Actions/ChangeShinyIntoBigItem.cs
@@ -84,17 +84,17 @@ namespace RandomizerMod.Actions
             charm.ClearTransitions();
             charm.AddTransition("FINISHED", "Big Item?");
 
-            // Check if each additive item has already been obtained. Give 100 geo instead of popup if so.
+            // Check if each additive item has already been obtained. Give 300 geo instead of popup if so.
             bigItem.ClearTransitions();
             bigItem.AddFirstAction(new RandomizerExecuteLambda(() => bigItem.AddTransition("FINISHED", BigItemPopup.AdditiveMaxedOut(_itemDefs) ? "Trink Flash" : "Big Get Flash"))); // if we have duplicates, the last item is not a big popup
 
-            // give 100 geo for last duplicate
+            // give 300 geo for last duplicate
             trinkFlash.ClearTransitions();
             trinkFlash.AddTransition("FINISHED", "Store Key");
             fsm.GetState("Trinket Type").ClearTransitions();
             trinkFlash.AddTransition("FINISHED", "Store Key");
             giveTrinket.RemoveActionsOfType<SetPlayerDataBool>();
-            giveTrinket.AddAction(new RandomizerExecuteLambda(() => GiveItem(GiveItemActions.GiveAction.AddGeo, _item, _location, new System.Random(RandomizerMod.Instance.Settings.Seed + _item.GetHashCode()).Next(100, 500))));
+            giveTrinket.AddAction(new RandomizerExecuteLambda(() => GiveItem(GiveItemActions.GiveAction.AddGeo, _item, _location, 300)));
             giveTrinket.GetActionsOfType<GetLanguageString>().First().convName = _itemDefs.Last().NameKey;
             giveTrinket.GetActionsOfType<SetSpriteRendererSprite>().First().sprite = RandomizerMod.GetSprite(Randomization.LogicManager.GetItemDef(_itemDefs.Last().Name).shopSpriteKey);
 

--- a/RandomizerMod3.0/RandoLogger.cs
+++ b/RandomizerMod3.0/RandoLogger.cs
@@ -557,12 +557,18 @@ namespace RandomizerMod
                 List<string> progression = new List<string>();
                 foreach ((int, string, string) pair in orderedILPairs)
                 {
-                    if (LogicManager.GetItemDef(pair.Item2).progression) progression.Add($"({pair.Item1}) {pair.Item2}<---at--->{pair.Item3}");
+                    string cost = "";
+                    if (LogicManager.TryGetItemDef(pair.Item3, out ReqDef itemDef)) {
+                        if (itemDef.cost != 0) cost = $" [{itemDef.cost} {itemDef.costType.ToString("g")}]";
+                    }
+                    else cost = $" [{RandomizerMod.Instance.Settings.GetShopCost(pair.Item2)} Geo]";
+
+                    if (LogicManager.GetItemDef(pair.Item2).progression) progression.Add($"({pair.Item1}) {pair.Item2}<---at--->{pair.Item3}{cost}");
                     if (LogicManager.TryGetItemDef(pair.Item3, out ReqDef locationDef))
                     {
-                        areaItemLocations[locationDef.areaName].Add($"({pair.Item1}) {pair.Item2}<---at--->{pair.Item3}");
+                        areaItemLocations[locationDef.areaName].Add($"({pair.Item1}) {pair.Item2}<---at--->{pair.Item3}{cost}");
                     }
-                    else areaItemLocations[pair.Item3].Add(pair.Item2);
+                    else areaItemLocations[pair.Item3].Add($"{pair.Item2}{cost}");
                 }
 
                 AddToLog(Environment.NewLine + "PROGRESSION ITEMS");

--- a/RandomizerMod3.0/RandomizerMod.cs
+++ b/RandomizerMod3.0/RandomizerMod.cs
@@ -183,7 +183,7 @@ namespace RandomizerMod
 
         public override string GetVersion()
         {
-            string ver = "3.07";
+            string ver = "3.07DAB";
             ver += $"({Math.Abs(MakeAssemblyHash() % 997)})";
 
             int minAPI = 53;


### PR DESCRIPTION
Item costs added to spoiler log by appending " [{cost} {costType}]" to locations.

For example, "Flukenest<---at--->Leg Eater [420 Geo]".

(this may or may not have been motivated by wanting to encourage spoiler log races :P)